### PR TITLE
feat(db): init sql.js + persistencia

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,78 +1,24 @@
-<<<<<<< HEAD
 # Yield-Huddle
-App de control de scrap
-=======
-# React + TypeScript + Vite
+App de control de scrap.
 
-This template provides a minimal setup to get React working in Vite with HMR and some ESLint rules.
+## Tech stack
+- React + TypeScript + Vite
+- Material UI (MUI)
+- Zustand (estado), React Query (datos), Recharts (gráficas)
+- sql.js + IndexedDB (persistencia local)
+- Tauri (empaquetado escritorio)
 
-Currently, two official plugins are available:
+## Scripts útiles
+- `npm run dev` – modo desarrollo (web)
+- `npm run build` – build web
+- `npm run tauri dev` – app de escritorio en dev
+- `npm run tauri build` – instalador de escritorio
 
-- [@vitejs/plugin-react](https://github.com/vitejs/vite-plugin-react/blob/main/packages/plugin-react) uses [Babel](https://babeljs.io/) for Fast Refresh
-- [@vitejs/plugin-react-swc](https://github.com/vitejs/vite-plugin-react/blob/main/packages/plugin-react-swc) uses [SWC](https://swc.rs/) for Fast Refresh
+## Vistas previstas
+- Diario / Semanal / Mensual
+- Minuta (asistencia y acciones)
+- Unidades sin clasificación
 
-## Expanding the ESLint configuration
-
-If you are developing a production application, we recommend updating the configuration to enable type-aware lint rules:
-
-```js
-export default tseslint.config([
-  globalIgnores(['dist']),
-  {
-    files: ['**/*.{ts,tsx}'],
-    extends: [
-      // Other configs...
-
-      // Remove tseslint.configs.recommended and replace with this
-      ...tseslint.configs.recommendedTypeChecked,
-      // Alternatively, use this for stricter rules
-      ...tseslint.configs.strictTypeChecked,
-      // Optionally, add this for stylistic rules
-      ...tseslint.configs.stylisticTypeChecked,
-
-      // Other configs...
-    ],
-    languageOptions: {
-      parserOptions: {
-        project: ['./tsconfig.node.json', './tsconfig.app.json'],
-        tsconfigRootDir: import.meta.dirname,
-      },
-      // other options...
-    },
-  },
-])
-```
-
-You can also install [eslint-plugin-react-x](https://github.com/Rel1cx/eslint-react/tree/main/packages/plugins/eslint-plugin-react-x) and [eslint-plugin-react-dom](https://github.com/Rel1cx/eslint-react/tree/main/packages/plugins/eslint-plugin-react-dom) for React-specific lint rules:
-
-```js
-// eslint.config.js
-import reactX from 'eslint-plugin-react-x'
-import reactDom from 'eslint-plugin-react-dom'
-
-export default tseslint.config([
-  globalIgnores(['dist']),
-  {
-    files: ['**/*.{ts,tsx}'],
-    extends: [
-      // Other configs...
-      // Enable lint rules for React
-      reactX.configs['recommended-typescript'],
-      // Enable lint rules for React DOM
-      reactDom.configs.recommended,
-    ],
-    languageOptions: {
-      parserOptions: {
-        project: ['./tsconfig.node.json', './tsconfig.app.json'],
-        tsconfigRootDir: import.meta.dirname,
-      },
-      // other options...
-    },
-  },
-])
-```
->>>>>>> 61f4c04 (chore: bootstrap scrap-control (vite+react-ts+pwa+tauri+sqlite))
-test
-test status checks
-test status checks
-trigger CI
+## Notas
+- Commits: Conventional Commits
+- Ramas: GitFlow (`develop`, `feature/*`, etc.)


### PR DESCRIPTION
## Objetivo
Integrar sql.js con IndexedDB para persistencia local offline-first.

## Cambios
- Configuración de `db/init.ts`.
- Definidos modelos base: `ScrapEntry`, `Supervisor`, `Especialista`.
- Persistencia automática en IndexedDB.

## Cómo probar
1. `npm run dev`
2. Insertar datos mock y validar persistencia tras recarga.

## Checklist
- [x] Tests/Build OK
- [x] Conventional commits
- [x] Docs/Changelog

Closes #9
